### PR TITLE
Fix demo on HuggingFace and polish README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# **Novel View Synthesis as Video Completion**
+<div align="center">
+
+# FrameCrafter: Novel View Synthesis as Video Completion
+
+[Qi Wu](https://szqwu.github.io/), [Khiem Vuong](https://www.khiemvuong.com/), [Minsik Jeon](https://msjeon.me/), [Srinivasa Narasimhan](https://www.cs.cmu.edu/~srinivas/), [Deva Ramanan](https://www.cs.cmu.edu/~deva/)
+
+Carnegie Mellon University
+
+[[`arXiv`](https://arxiv.org/abs/2604.08500)]
+[[`Project Page`](https://frame-crafter.github.io/)]
+
+</div>
 
 ## Overview
 We tackle the problem of sparse novel view synthesis (NVS) using video diffusion models: given *K* (≈ 5) multi-view images of a scene and their camera poses, we predict the view from a target camera pose. Many prior approaches leverage generative image priors encoded via diffusion models. However, models trained on single images lack multi-view knowledge. We instead argue that video models already contain implicit multi-view knowledge and so should be easier to adapt for NVS. Our key insight is to formulate sparse NVS as a low frame-rate video completion task. However, one challenge is that sparse NVS is defined over an unordered set of inputs, often too sparse to admit a meaningful order, so the models should be *invariant* to permutations of that input set. To this end, we present **FrameCrafter**, which adapts video models (naturally trained with coherent frame orderings) to permutation-invariant NVS through several architectural modifications, including per-frame latent encodings and removal of temporal positional embeddings. Our results suggest that video models can be easily trained to "forget" about time with minimal supervision, producing competitive performance on sparse-view NVS benchmarks.
@@ -14,7 +25,23 @@ pip install -e .
 ## Backbone Weights
 
 The model requires pre-trained Wan2.1 backbone weights (DiT 14B, T5 text
-encoder, VAE, CLIP image encoder). Pass the directory via `base_model_dir`:
+encoder, VAE, CLIP image encoder). **By default these are downloaded
+automatically on first run into `./models/`** — no setup needed.
+
+**Choosing the download source.** Defaults to ModelScope. To download from
+HuggingFace instead (often faster outside China):
+
+```bash
+export DIFFSYNTH_DOWNLOAD_SOURCE=huggingface
+```
+
+**Custom download location.** Override the default `./models/` directory:
+
+```bash
+export DIFFSYNTH_MODEL_BASE_PATH=/path/to/backbone/weights
+```
+
+Or pass it explicitly when loading the model:
 
 ```python
 model = FrameCrafter(
@@ -22,9 +49,6 @@ model = FrameCrafter(
     base_model_dir="/path/to/backbone/weights",
 )
 ```
-
-If `base_model_dir` is `None`, weights are downloaded automatically from
-ModelScope/HuggingFace on first run.
 
 ## Model Weights
 
@@ -38,6 +62,27 @@ This places the checkpoint at `ckpt/framecrafter.safetensors` (the default path 
 
 ## Quick Start
 
+### Demo
+
+Run on bundled example scenes. Backbone weights
+will be downloaded automatically to `./models/` on first run. The three examples
+(`example1`, `example2`, `example3`) showcase different M-to-N configurations:
+6-to-1, 6-to-2, and 3-to-1.
+
+```bash
+# Run first example scene
+python demo.py
+
+# Run a specific scene
+python demo.py --scene example2
+
+# Run all 3 example scenes
+python demo.py --all
+```
+
+Generated frames are saved to `demo_output/<scene_name>/`. Use
+`--output_dir <path>` to change the location.
+
 ### Python API
 
 ```python
@@ -45,11 +90,9 @@ from model import FrameCrafter
 import numpy as np
 from PIL import Image
 
-# Load model
-model = FrameCrafter(
-    "ckpt/framecrafter.safetensors",
-    base_model_dir="/path/to/backbone/weights",
-)
+# Load model (backbone weights auto-download to ./models/ on first run;
+# pass base_model_dir=... to use a pre-downloaded location)
+model = FrameCrafter("ckpt/framecrafter.safetensors")
 
 # Prepare inputs -- M context images, M+N poses (M context + N target)
 M = 6  # number of context views (flexible)
@@ -76,7 +119,6 @@ for i, novel_view in enumerate(video[M:]):
 
 ```bash
 python infer.py \
-    --base_model_dir /path/to/backbone/weights \
     --images ctx_0.png ctx_1.png ctx_2.png ctx_3.png ctx_4.png ctx_5.png \
     --poses_npz scene.npz \
     --height 480 --width 832 \
@@ -84,18 +126,8 @@ python infer.py \
     --output_dir results/
 ```
 
-### Demo
-
-Run on bundled example scenes. The three examples showcase different M-to-N
-configurations: 6-to-1, 6-to-2, and 3-to-1.
-
-```bash
-# Run first example scene
-python demo.py --base_model_dir /path/to/backbone/weights
-
-# Run all 3 example scenes
-python demo.py --base_model_dir /path/to/backbone/weights --all
-```
+Add `--base_model_dir /path/to/backbone/weights` if you have the backbone
+weights pre-downloaded somewhere other than `./models/`.
 
 ## Input Format
 
@@ -145,7 +177,6 @@ FrameCrafter/
 ├── infer.py              # CLI for inference
 ├── demo.py               # Demo script for bundled examples
 ├── camera_utils.py       # Plucker ray computation & pose normalisation
-├── assets/               # Visual examples
 ├── diffsynth/            # Core diffusion library
 ├── examples/             # Bundled demo scenes (inputs + poses)
 ├── prepare/              # Scripts for downloading checkpoints
@@ -155,4 +186,21 @@ FrameCrafter/
 
 ## License
 
-This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.
+This project is licensed under the Apache 2.0 License. See [LICENSE](LICENSE) for details.
+
+## Acknowledgement
+
+We thank the authors of [DiffSynth-Studio](https://github.com/modelscope/DiffSynth-Studio) and [Wan2.1](https://github.com/Wan-Video/Wan2.1) for releasing their code and pretrained models, which this project builds upon.
+
+## Citation
+
+If you find this work useful, please consider citing:
+
+```bibtex
+@article{Wu2026framecrafter,
+  title={Novel View Synthesis as Video Completion},
+  author={Qi Wu and Khiem Vuong and Minsik Jeon and Srinivasa Narasimhan and Deva Ramanan},
+  year={2026},
+  journal={arXiv preprint arXiv:2604.08500},
+}
+```

--- a/model.py
+++ b/model.py
@@ -199,9 +199,38 @@ class FrameCrafter:
         if base_model_dir is not None:
             dit_dir = os.path.join(base_model_dir, "Wan-AI/Wan2.1-I2V-14B-480P")
             dit_files = sorted(_glob.glob(os.path.join(dit_dir, "diffusion_pytorch_model*.safetensors")))
-            t5_path = os.path.join(base_model_dir, "DiffSynth-Studio/Wan-Series-Converted-Safetensors/models_t5_umt5-xxl-enc-bf16.safetensors")
-            vae_path = os.path.join(base_model_dir, "DiffSynth-Studio/Wan-Series-Converted-Safetensors/Wan2.1_VAE.safetensors")
-            clip_path = os.path.join(base_model_dir, "DiffSynth-Studio/Wan-Series-Converted-Safetensors/models_clip_open-clip-xlm-roberta-large-vit-huge-14.safetensors")
+
+            # Resolve T5/VAE/CLIP from whichever layout is present:
+            #   - ModelScope:   DiffSynth-Studio/Wan-Series-Converted-Safetensors/*.safetensors
+            #   - HuggingFace:  Wan-AI/Wan2.1-I2V-14B-480P/*.pth
+            converted_dir = os.path.join(base_model_dir, "DiffSynth-Studio/Wan-Series-Converted-Safetensors")
+            def _resolve(name_safetensors: str, name_pth: str, label: str) -> str:
+                converted = os.path.join(converted_dir, name_safetensors)
+                original = os.path.join(dit_dir, name_pth)
+                if os.path.exists(converted):
+                    return converted
+                if os.path.exists(original):
+                    return original
+                raise FileNotFoundError(
+                    f"Could not find {label} weights under {base_model_dir}. "
+                    f"Looked for:\n  {converted}\n  {original}"
+                )
+
+            t5_path = _resolve(
+                "models_t5_umt5-xxl-enc-bf16.safetensors",
+                "models_t5_umt5-xxl-enc-bf16.pth",
+                "T5 text encoder",
+            )
+            vae_path = _resolve(
+                "Wan2.1_VAE.safetensors",
+                "Wan2.1_VAE.pth",
+                "VAE",
+            )
+            clip_path = _resolve(
+                "models_clip_open-clip-xlm-roberta-large-vit-huge-14.safetensors",
+                "models_clip_open-clip-xlm-roberta-large-vit-huge-14.pth",
+                "CLIP image encoder",
+            )
             tokenizer_path = os.path.join(base_model_dir, "Wan-AI/Wan2.1-T2V-1.3B/google/umt5-xxl")
 
             model_configs = [
@@ -220,11 +249,20 @@ class FrameCrafter:
             ]
             tokenizer_config = ModelConfig(model_id="Wan-AI/Wan2.1-T2V-1.3B", origin_file_pattern="google/umt5-xxl/")
 
+        # `redirect_common_files` rewrites the T5/VAE/CLIP file ids to
+        # `DiffSynth-Studio/Wan-Series-Converted-Safetensors`, which only
+        # exists on ModelScope. Disable the redirect when downloading from
+        # HuggingFace so the original .pth files are pulled from the
+        # `Wan-AI/Wan2.1-I2V-14B-480P` repo instead.
+        download_source = os.environ.get("DIFFSYNTH_DOWNLOAD_SOURCE", "modelscope")
+        redirect_common_files = download_source.lower() != "huggingface"
+
         self.pipe = WanVideoPipeline.from_pretrained(
             torch_dtype=torch.bfloat16,
             device=device,
             model_configs=model_configs,
             tokenizer_config=tokenizer_config,
+            redirect_common_files=redirect_common_files,
             vram_limit=vram_limit,
         )
         self._modify_channels(self.IN_DIM)

--- a/prepare/download_ckpt.sh
+++ b/prepare/download_ckpt.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-rm -rf ckpt
 echo -e "Downloading FrameCrafter ckpts"
-mkdir ckpt
+mkdir -p ckpt
 cd ckpt
 gdown --fuzzy https://drive.google.com/file/d/1eaEay33yAfE8IJJdO-avZZCr-eGD4OZK/view
 
-unzip framecrafter.zip
+unzip -o framecrafter.zip
 
 echo -e "Cleaning\n"
 rm framecrafter.zip


### PR DESCRIPTION
## Summary
  - **`model.py`**: auto-detect `.safetensors` (ModelScope) vs `.pth` (HuggingFace) backbone layouts under `base_model_dir`, and disable the `Wan-Series-Converted-Safetensors` file redirect when downloading from HuggingFace (that converted repo only exists on ModelScope, so the redirect 404s on HF).
  - **`prepare/download_ckpt.sh`**: drop `rm -rf ckpt`; use `mkdir -p` and `unzip -o` so re-running the script is non-destructive.